### PR TITLE
Save key

### DIFF
--- a/src/upload/TokenFunc.ts
+++ b/src/upload/TokenFunc.ts
@@ -1,0 +1,8 @@
+import Uploader from "./Uploader";
+import BaseTask from "./task/BaseTask";
+
+interface TokenFunc {
+    (uploader: Uploader, task: BaseTask): string | Promise<string>;
+}
+
+export default TokenFunc;

--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -300,7 +300,7 @@ class Uploader {
      * 检验选项合法性
      */
     private  validateOptions(): void {
-        if (!this.tokenFunc) {
+        if (!this._tokenFunc) {
             throw new Error('你必须提供一个获取Token的回调函数');
         }
         if (!this.scale || !this.scale instanceof Array || this.scale.length != 2 || this.scale[0] < 0 || this.scale[1] < 0) {
@@ -360,6 +360,20 @@ class Uploader {
         this.fileInput.click();
     }
 
+    public getToken(task: BaseTask): Promise<string> {
+        if (this._tokenShare && this._token != undefined) {
+            return Promise.resolve(this._token);
+        }
+        debug.d(`开始获取上传token`);
+        return new Promise((resolve) => {
+            this._tokenFunc(resolve, task);
+        }).then((token: string): string => {
+            debug.d(`上传token获取成功 ${token}`);
+            this._token = token;
+            return token;
+        });
+    }
+
     get retry(): number {
         return this._retry;
     }
@@ -396,24 +410,8 @@ class Uploader {
         return this._fileInput;
     }
 
-    get tokenShare(): boolean {
-        return this._tokenShare;
-    }
-
     get chunk(): boolean {
         return this._chunk;
-    }
-
-    get tokenFunc(): Function {
-        return this._tokenFunc;
-    }
-
-    get token(): string {
-        return this._token;
-    }
-
-    set token(value: string) {
-        this._token = value;
     }
 
     get taskQueue(): BaseTask[] {

--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -1,6 +1,7 @@
 import BaseTask from "./task/BaseTask";
 import DirectTask from "./task/DirectTask";
 import {ChunkTask} from "./task/ChunkTask";
+import TokenFunc from "./TokenFunc";
 import UploaderBuilder from "./UploaderBuilder";
 import debug from "../util/Debug";
 import Interceptor from "./interceptor/UploadInterceptor";
@@ -29,7 +30,7 @@ class Uploader {
     private _compress: number;//图片压缩质量
     private _scale: number[] = [];//缩放大小,限定高度等比缩放[h:200,w:0],限定宽度等比缩放[h:0,w:100],限定长宽[h:200,w:100]
     private _listener: UploadListener;//监听器
-    private _tokenFunc: Function;//token获取函数
+    private _tokenFunc: TokenFunc;//token获取函数
     private _tokenShare: boolean;//分享token,如果为false,每一次HTTP请求都需要新获取Token
     private _interceptors: Interceptor[];//任务拦截器
     private _domain: string;//上传域名
@@ -365,9 +366,7 @@ class Uploader {
             return Promise.resolve(this._token);
         }
         debug.d(`开始获取上传token`);
-        return new Promise((resolve) => {
-            this._tokenFunc(resolve, task);
-        }).then((token: string): string => {
+        return Promise.resolve(this._tokenFunc(this, task)).then((token: string): string => {
             debug.d(`上传token获取成功 ${token}`);
             this._token = token;
             return token;

--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -2,6 +2,7 @@ import BaseTask from "./task/BaseTask";
 import DirectTask from "./task/DirectTask";
 import {ChunkTask} from "./task/ChunkTask";
 import TokenFunc from "./TokenFunc";
+import UUID from "./uuid/UUID";
 import UploaderBuilder from "./UploaderBuilder";
 import debug from "../util/Debug";
 import Interceptor from "./interceptor/UploadInterceptor";
@@ -414,7 +415,16 @@ class Uploader {
             return Promise.resolve(undefined);
         }
         return Promise.resolve(saveKey)
+            .then(this.resolveUUID)
             .then(this.onSaveKeyResolved);
+    }
+
+    private resolveUUID = (s: string): string => {
+        let re = /\$\(uuid\)/;
+        if (re.test(s)) {
+            return s.replace(re, UUID.uuid());
+        }
+        return s;
     }
 
     private onSaveKeyResolved = (saveKey: string): string => {

--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -416,6 +416,7 @@ class Uploader {
         }
         return Promise.resolve(saveKey)
             .then(this.resolveUUID)
+            .then(saveKey => this.resolveImageInfo(task.file, saveKey))
             .then(this.onSaveKeyResolved);
     }
 
@@ -425,6 +426,23 @@ class Uploader {
             return s.replace(re, UUID.uuid());
         }
         return s;
+    }
+
+    private resolveImageInfo = (blob: Blob, s: string): Promise<string> => {
+        let widthRe = /\$\(imageInfo\.width\)/;
+        let heightRe = /\$\(imageInfo\.height\)/;
+        if (!widthRe.test(s) && !heightRe.test(s)) {
+            return Promise.resolve(s);
+        }
+        return new Promise<string>((resolve) => {
+            let img = new Image();
+            img.src = URL.createObjectURL(blob);
+            img.onload = () => {
+                s = s.replace(widthRe, img.width.toString());
+                s = s.replace(heightRe, img.height.toString());
+                resolve(s);
+            };
+        });
     }
 
     private onSaveKeyResolved = (saveKey: string): string => {

--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -373,6 +373,32 @@ class Uploader {
         });
     }
 
+    public requestTaskToken(task: BaseTask, url: string): Promise<string> {
+        return this.requestToken(url);
+    }
+
+    private requestToken(url: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+
+            let xhr: XMLHttpRequest = new XMLHttpRequest();
+            xhr.open('GET', url, true);
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState != XMLHttpRequest.DONE) {
+                    return;
+                }
+                if (xhr.status == 200) {
+                    resolve(xhr.response.uptoken);
+                    return;
+                }
+                reject(xhr.response);
+            };
+            xhr.onabort = () => { reject('aborted'); };
+            xhr.responseType = 'json';
+            xhr.send();
+        });
+    }
+
     get retry(): number {
         return this._retry;
     }

--- a/src/upload/UploaderBuilder.ts
+++ b/src/upload/UploaderBuilder.ts
@@ -26,6 +26,7 @@ class UploaderBuilder {
     private _compress: number = 1;//图片压缩质量
     private _scale: number[] = [0, 0];//缩放大小,限定高度等比[h:200,w:0],限定宽度等比[h:0,w:100],限定长宽[h:200,w:100]
     private _listener: UploadListener;//监听器
+    private _saveKey: boolean | string = false;
     private _tokenFunc: TokenFunc;//token获取函数
     private _tokenShare: boolean = true;//分享token,如果为false,每一次HTTP请求都需要新获取Token
     private _interceptors: Interceptor[] = [];//任务拦截器
@@ -136,6 +137,16 @@ class UploaderBuilder {
     }
 
     /**
+     * 设置 saveKey
+     * @param saveKey
+     * @returns {UploaderBuilder}
+     */
+    public saveKey(saveKey: boolean | string): UploaderBuilder {
+        this._saveKey = saveKey;
+        return this;
+    }
+
+    /**
      * 获取Token的地址
      * @param tokenUrl
      * @returns {UploaderBuilder}
@@ -231,6 +242,10 @@ class UploaderBuilder {
 
     get getListener(): UploadListener {
         return this._listener;
+    }
+
+    get getSaveKey(): boolean | string {
+        return this._saveKey;
     }
 
     get getTokenFunc(): TokenFunc {

--- a/src/upload/UploaderBuilder.ts
+++ b/src/upload/UploaderBuilder.ts
@@ -1,4 +1,6 @@
 import Uploader from "./Uploader";
+import BaseTask from "./task/BaseTask";
+import TokenFunc from "./TokenFunc";
 import Interceptor from "./interceptor/UploadInterceptor";
 import UploadListener from "./hook/UploadListener";
 import {Scheme, Domain} from "./url/Domain";
@@ -24,7 +26,7 @@ class UploaderBuilder {
     private _compress: number = 1;//图片压缩质量
     private _scale: number[] = [0, 0];//缩放大小,限定高度等比[h:200,w:0],限定宽度等比[h:0,w:100],限定长宽[h:200,w:100]
     private _listener: UploadListener;//监听器
-    private _tokenFunc: Function;//token获取函数
+    private _tokenFunc: TokenFunc;//token获取函数
     private _tokenShare: boolean = true;//分享token,如果为false,每一次HTTP请求都需要新获取Token
     private _interceptors: Interceptor[] = [];//任务拦截器
     private _isDebug: boolean = false;//
@@ -139,7 +141,11 @@ class UploaderBuilder {
      * @returns {UploaderBuilder}
      */
     public tokenFunc(tokenFunc): UploaderBuilder {
-        this._tokenFunc = tokenFunc;
+        this._tokenFunc = (uploader: Uploader, task: BaseTask) => {
+            return new Promise((resolve) => {
+                tokenFunc(resolve, task);
+            });
+        };
         return this;
     }
 
@@ -215,7 +221,7 @@ class UploaderBuilder {
         return this._listener;
     }
 
-    get getTokenFunc(): Function {
+    get getTokenFunc(): TokenFunc {
         return this._tokenFunc;
     }
 

--- a/src/upload/UploaderBuilder.ts
+++ b/src/upload/UploaderBuilder.ts
@@ -136,6 +136,18 @@ class UploaderBuilder {
     }
 
     /**
+     * 获取Token的地址
+     * @param tokenUrl
+     * @returns {UploaderBuilder}
+     */
+    public tokenUrl(tokenUrl): UploaderBuilder {
+        this._tokenFunc = (uploader: Uploader, task: BaseTask) => {
+            return uploader.requestTaskToken(task, tokenUrl);
+        }
+        return this;
+    }
+
+    /**
      * 获取Token的函数
      * @param tokenFunc
      * @returns {UploaderBuilder}

--- a/src/upload/pattren/ChunkUploadPattern.ts
+++ b/src/upload/pattren/ChunkUploadPattern.ts
@@ -16,19 +16,11 @@ class ChunkUploadPattern implements IUploadPattern {
 
     upload(task: ChunkTask): void {
         this.task = task;
-        if (this.uploader.tokenShare && this.uploader.token) {
+
+        this.uploader.getToken(task).then((token: string) => {
             task.startDate = new Date();
-            this.uploadBlock(this.uploader.token);
-        }
-        else {
-            debug.d(`开始获取token`);
-            this.uploader.tokenFunc((token: string) => {
-                debug.d(`token获取成功 ${token}`);
-                this.uploader.token = token;
-                task.startDate = new Date();
-                this.uploadBlock(token);
-            }, task);
-        }
+            this.uploadBlock(token);
+        });
     }
 
     private uploadBlock(token: string) {

--- a/src/upload/pattren/DirectUploadPattern.ts
+++ b/src/upload/pattren/DirectUploadPattern.ts
@@ -20,20 +20,10 @@ class DirectUploadPattern implements IUploadPattern {
     upload(task: DirectTask): void {
         this.task = task;
 
-        if (this.uploader.tokenShare && this.uploader.token) {
-            debug.d(`使用上次token进行上传`);
+        this.uploader.getToken(task).then((token: string) => {
             task.startDate = new Date();
-            this.uploadFile(this.uploader.token);
-        }
-        else {
-            debug.d(`开始获取上传token`);
-            this.uploader.tokenFunc((token: string) => {
-                debug.d(`上传token获取成功 ${token}`);
-                this.uploader.token = token;
-                task.startDate = new Date();
-                this.uploadFile(this.uploader.token);
-            }, task);
-        }
+            this.uploadFile(token);
+        });
     }
 
 

--- a/src/upload/uuid/UUID.ts
+++ b/src/upload/uuid/UUID.ts
@@ -1,0 +1,13 @@
+class UUID {
+    public static uuid(): string {
+        let d = new Date().getTime();
+        let uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            let r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+            return (c=='x' ? r : (r&0x3|0x8)).toString(16);
+        });
+        return uuid;
+    }
+}
+
+export default UUID;


### PR DESCRIPTION
The main purpose of this pr is to add `saveKey` support with client side magic variable resolution. 

Currently three magic variables, which are [statement][qiniu-statement] as unsupported in `saveKey` by Qiniu, are resolved in client side. There are $(uuid), $(imageInfo.width) and $(imageInfo.height).

In order to support `saveKey`, this pr add support to get token through http get request. This function is compatible with [qiniu/js-sdk][]'s `uptoken_url`.

Additionally, token getting logic was separated and moved from upload patterns to uploader.

[qiniu-statement]: http://developer.qiniu.com/article/kodo/kodo-developer/up/vars.html
[qiniu/js-sdk]: https://github.com/qiniu/js-sdk