### PR TITLE
Fix usage of private token in uploader

### DIFF
--- a/src/upload/Uploader.ts
+++ b/src/upload/Uploader.ts
@@ -529,10 +529,6 @@ class Uploader {
     get domain(): string {
         return this._domain;
     }
-
-    get token(): string {
-        return this._token;
-    }
 }
 
 export default Uploader;

--- a/src/upload/pattren/ChunkUploadPattern.ts
+++ b/src/upload/pattren/ChunkUploadPattern.ts
@@ -28,7 +28,7 @@ class ChunkUploadPattern implements IUploadPattern {
         for (let block: Block of this.task.blocks) {
             for (let chunk: Chunk of block.chunks) {
                 chain = chain.then(() => {
-                    return this.uploadChunk(chunk, this.uploader.token)
+                    return this.uploadChunk(chunk, token)
                 });
             }
         }


### PR DESCRIPTION
This is a bug introduced in PR #12, commit 62c0f573.

Fixes #17.


PR #12 中的 62c0f573 将 token 获取逻辑从 upload patterns 统一到了 uploader 里。Upload patterns 通过 uploader 的接口 `public getToken(task: BaseTask): Promise<string>` 获得上传需要的 token ，而不需要知道这个 token 是怎么获得的，是否是共享的。`ChunkUploadPattern` 有一处使用老接口获取 token 的地方没有改过来，导致了这个 bug 。